### PR TITLE
Sérialiser les lancements de scripts planifiés

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ autopadel/
   ```
 - Audit de sécurité des dépendances intégré
 
+## 🧵 Gestion séquentielle des scripts
+- Tous les lancements de `index.mjs` passent par une file d'attente interne (`enqueueRun`).
+- La file garantit qu'une seule instance du script s'exécute à la fois, avec une courte pause entre deux jobs.
+- Les codes de sortie sont journalisés à la fermeture du processus enfant. En cas d'erreur lors du lancement, celle-ci est loguée et la file poursuit les exécutions suivantes.
+
 ---
 
 ## 🤝 Contribuer


### PR DESCRIPTION
## Summary
- add a simple promise-based queue so only one index.mjs run happens at a time and log exit codes
- route all scheduled and test launches through enqueueRun with an optional context and short cooldown
- document the sequential queue behaviour in the README to avoid reintroducing parallel spawns

## Testing
- npm test *(fails: puppeteer cannot launch in the container because libatk-1.0 is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8786072c83258464ede0c00278e0