### PR TITLE
Add HTTP-based automation runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ autopadel/
 - (Optionnel) Activez le mode test
 - Cliquez sur **Lancer l’autologin** pour réserver
 
+## 🛠️ Moteurs d'automatisation
+- **Puppeteer (`engine: "puppeteer"`)** : moteur historique basé sur un navigateur Chromium automatisé. Il reste disponible pour les scénarios nécessitant une reproduction fidèle de l'interface web.
+- **HTTP (`engine: "http"`)** : nouveau client léger qui rejoue directement les requêtes réseau. Il peut être configuré via la clé `http` du fichier `config.js` (sélecteurs spécifiques, endpoints, mode mock, etc.).
+  - Pour des tests hors-ligne, définissez `http.mode: "mock"` et fournissez des créneaux fictifs (`http.mockData.availableSlots`).
+  - En mode « live », le script tente la connexion et la réservation à partir des informations fournies, sans lancer Chromium.
+
 ---
 
 ## 🔒 Sécurité & Tests

--- a/config.js
+++ b/config.js
@@ -2,6 +2,10 @@
 export default {
   "loginUrl": "https://centralsportclub.gestion-sports.com/connexion.php?",
   "memberUrl": "https://centralsportclub.gestion-sports.com/membre/",
+  "engine": "http",
+  "http": {
+    "mode": "live"
+  },
   "username": "rocqueslio@gmail.com",
   "password": "q9cw!hK9BPFEWZd",
   "useCourtPreferences": true,

--- a/config_test.js
+++ b/config_test.js
@@ -1,0 +1,32 @@
+export default {
+  loginUrl: 'https://example.com/connexion',
+  memberUrl: 'https://example.com/membre/',
+  engine: 'http',
+  http: {
+    mode: 'mock',
+    mockData: {
+      availableSlots: [
+        { courtId: '1455', courtName: 'ADN Family', hour: '14:00', slotId: 'slot-1455-1400' },
+        { courtId: '1456', courtName: 'Agence Donibane', hour: '16:00', slotId: 'slot-1456-1600' },
+        { courtId: '1692', courtName: "AU P'TIT DOLMEN", hour: '18:00', slotId: 'slot-1692-1800' }
+      ],
+      onSuccessMessage: 'Simulation de réservation réussie (config_test).'
+    }
+  },
+  username: 'test@example.com',
+  password: 'password',
+  useCourtPreferences: true,
+  courts: {
+    '1455': 'ADN Family',
+    '1456': 'Agence Donibane',
+    '1692': "AU P'TIT DOLMEN",
+    preferences: ['1455', '1456']
+  },
+  partners: [
+    { position: 0, playerId: '148146', playerName: 'Partenaire 1' },
+    { position: 1, playerId: '148147', playerName: 'Partenaire 2' }
+  ],
+  hourPreferences: ['14:00', '16:00', '18:00'],
+  bookingAdvance: 0,
+  testMode: true
+};

--- a/http-runner.mjs
+++ b/http-runner.mjs
@@ -1,0 +1,728 @@
+import axios from 'axios';
+import { wrapper } from 'axios-cookiejar-support';
+import { CookieJar } from 'tough-cookie';
+import * as cheerio from 'cheerio';
+
+const DEFAULT_HTTP_SETTINGS = {
+  mode: 'live',
+  userAgent:
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36',
+  requestHeaders: {
+    html: {
+      Accept:
+        'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+      'Accept-Language': 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7'
+    }
+  },
+  endpoints: {
+    login: {
+      method: 'POST',
+      fetchInitialPage: true,
+      formSelector: 'form',
+      usernameField: 'email',
+      passwordField: 'pass',
+      encoding: 'form'
+    },
+    reservationPage: {
+      path: 'reservation.html',
+      method: 'GET',
+      dateFormat: 'DD/MM/YYYY',
+      dateQueryParam: 'date'
+    },
+    finalize: {
+      method: 'POST',
+      encoding: 'form',
+      fields: {
+        court: 'idcourt',
+        slot: 'idhoraire',
+        hour: 'heure',
+        date: 'date',
+        testMode: 'test',
+        partner: 'idplayer_{position}'
+      }
+    }
+  },
+  selectors: {
+    reservationForm: [
+      'form#formReservation',
+      'form#reservation-form',
+      'form[action*="reservation"]',
+      'form[name="formReservation"]'
+    ],
+    court: '.bloccourt',
+    courtIdAttr: 'data-idcourt',
+    courtName: '.blocCourt_title, .blocCourt_top h3, .court-name',
+    slotButton: '.blocCourt_container_btn-creneau button.btn_creneau',
+    slotIdAttr: 'idhoraire',
+    skipDisabledClass: ['disabled', 'btn_creneau__indispo']
+  },
+  mockData: null
+};
+
+function deepMerge(base, override) {
+  const result = Array.isArray(base) ? [...base] : { ...base };
+  if (!override || typeof override !== 'object') {
+    return result;
+  }
+  for (const [key, value] of Object.entries(override)) {
+    const baseValue = result[key];
+    if (
+      baseValue &&
+      typeof baseValue === 'object' &&
+      !Array.isArray(baseValue) &&
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value)
+    ) {
+      result[key] = deepMerge(baseValue, value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function normaliseHour(value) {
+  if (!value) return null;
+  const raw = String(value).trim();
+  if (!raw) return null;
+  const lower = raw.toLowerCase();
+  const hMatch = lower.match(/^(\d{1,2})\s*h\s*(\d{2})$/);
+  if (hMatch) {
+    return `${hMatch[1].padStart(2, '0')}:${hMatch[2]}`;
+  }
+  const colonMatch = lower.match(/^(\d{1,2}):(\d{2})$/);
+  if (colonMatch) {
+    return `${colonMatch[1].padStart(2, '0')}:${colonMatch[2]}`;
+  }
+  const compactMatch = lower.match(/^(\d{3,4})$/);
+  if (compactMatch) {
+    const digits = compactMatch[1].padStart(4, '0');
+    return `${digits.slice(0, 2)}:${digits.slice(2)}`;
+  }
+  return raw;
+}
+
+function hourToMinutes(value) {
+  const normalised = normaliseHour(value);
+  if (!normalised) return Number.NaN;
+  const [hours, minutes] = normalised.split(':').map(Number);
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    return Number.NaN;
+  }
+  return hours * 60 + minutes;
+}
+
+function computeHourScore(hour, preferences) {
+  const normalised = normaliseHour(hour);
+  if (!normalised) {
+    return { score: Number.POSITIVE_INFINITY };
+  }
+  const exactIndex = preferences.findIndex(
+    (pref) => normaliseHour(pref) === normalised
+  );
+  if (exactIndex !== -1) {
+    return {
+      score: exactIndex,
+      fallback: false,
+      matchedPreference: preferences[exactIndex],
+      difference: 0
+    };
+  }
+  const hourMinutes = hourToMinutes(normalised);
+  if (!Number.isFinite(hourMinutes)) {
+    return { score: Number.POSITIVE_INFINITY };
+  }
+  let best = null;
+  preferences.forEach((pref, index) => {
+    const prefMinutes = hourToMinutes(pref);
+    if (!Number.isFinite(prefMinutes)) return;
+    const diff = Math.abs(prefMinutes - hourMinutes);
+    if (diff <= 30) {
+      const score = preferences.length + diff + index / 100;
+      if (!best || score < best.score) {
+        best = {
+          score,
+          fallback: true,
+          matchedPreference: pref,
+          difference: diff
+        };
+      }
+    }
+  });
+  return best || { score: Number.POSITIVE_INFINITY };
+}
+
+function computeCourtScore(courtId, preferences, usePreferences) {
+  if (!usePreferences || !Array.isArray(preferences) || preferences.length === 0) {
+    return 0;
+  }
+  const id = String(courtId ?? '');
+  const index = preferences.findIndex((pref) => String(pref) === id);
+  if (index !== -1) {
+    return index;
+  }
+  return preferences.length + 1;
+}
+
+function selectBestSlot(slots, config, log) {
+  if (!Array.isArray(slots) || slots.length === 0) {
+    return { slot: null };
+  }
+  const hourPreferences = Array.isArray(config.hourPreferences)
+    ? config.hourPreferences
+    : [];
+  const courtPreferences = Array.isArray(config?.courts?.preferences)
+    ? config.courts.preferences.map(String)
+    : [];
+  const scored = slots
+    .map((slot) => {
+      const hourInfo = computeHourScore(slot.hour, hourPreferences);
+      const courtScore = computeCourtScore(
+        slot.courtId,
+        courtPreferences,
+        Boolean(config.useCourtPreferences)
+      );
+      return { slot, hourInfo, courtScore };
+    })
+    .filter((entry) => Number.isFinite(entry.hourInfo.score));
+
+  if (scored.length === 0) {
+    log(
+      'warning',
+      'Aucun créneau ne correspond exactement ni approximativement aux horaires préférés.'
+    );
+    return { slot: null };
+  }
+
+  scored.sort((a, b) => {
+    if (a.courtScore !== b.courtScore) {
+      return a.courtScore - b.courtScore;
+    }
+    if (a.hourInfo.score !== b.hourInfo.score) {
+      return a.hourInfo.score - b.hourInfo.score;
+    }
+    return 0;
+  });
+
+  const best = scored[0];
+  const result = {
+    slot: {
+      ...best.slot,
+      matchedPreference: best.hourInfo.matchedPreference,
+      fallback: Boolean(best.hourInfo.fallback),
+      difference: best.hourInfo.difference ?? 0
+    },
+    fallback: Boolean(best.hourInfo.fallback),
+    matchedPreference: best.hourInfo.matchedPreference,
+    difference: best.hourInfo.difference ?? 0
+  };
+
+  if (result.slot.fallback) {
+    log(
+      'warning',
+      `Aucun horaire strictement préféré disponible, sélection du créneau ${result.slot.hour} (écart ${result.difference} minutes par rapport à ${result.matchedPreference || 'N/A'}).`
+    );
+  }
+
+  return result;
+}
+
+function extractAttributes(element) {
+  const attributes = {};
+  if (!element || !element.attribs) {
+    return attributes;
+  }
+  for (const [key, value] of Object.entries(element.attribs)) {
+    attributes[key] = value;
+    if (key.startsWith('data-')) {
+      const normalized = key.slice(5);
+      attributes[normalized] = value;
+    }
+  }
+  return attributes;
+}
+
+function extractForm($, selectors) {
+  let form = null;
+  if (Array.isArray(selectors)) {
+    for (const selector of selectors) {
+      const candidate = $(selector);
+      if (candidate && candidate.length) {
+        form = candidate.first();
+        break;
+      }
+    }
+  } else if (selectors) {
+    const candidate = $(selectors);
+    if (candidate && candidate.length) {
+      form = candidate.first();
+    }
+  }
+  if (!form || !form.length) {
+    const first = $('form').first();
+    if (first && first.length) {
+      form = first;
+    }
+  }
+  if (!form || !form.length) {
+    return { action: null, method: 'POST', fields: {} };
+  }
+  const fields = {};
+  form.find('input, select, textarea').each((_, elem) => {
+    const $elem = $(elem);
+    const name = $elem.attr('name');
+    if (!name) return;
+    const tag = (elem.tagName || elem.name || '').toLowerCase();
+    const type = ($elem.attr('type') || '').toLowerCase();
+    if (tag === 'select') {
+      const selected = $elem.find('option[selected]');
+      if (selected.length) {
+        fields[name] = selected.attr('value') ?? selected.text().trim();
+      }
+      return;
+    }
+    if (type === 'checkbox' || type === 'radio') {
+      if ($elem.is(':checked')) {
+        fields[name] = $elem.attr('value') ?? 'on';
+      }
+      return;
+    }
+    fields[name] = $elem.attr('value') ?? '';
+  });
+  return {
+    action: form.attr('action') || null,
+    method: (form.attr('method') || 'POST').toUpperCase(),
+    fields
+  };
+}
+
+function parseSlotsFromHtml(html, config, httpSettings) {
+  if (!html) {
+    return { form: { action: null, method: 'POST', fields: {} }, slots: [] };
+  }
+  const $ = cheerio.load(html);
+  const form = extractForm($, httpSettings.selectors.reservationForm);
+  const slots = [];
+  $(httpSettings.selectors.court).each((_, courtElement) => {
+    const attributes = extractAttributes(courtElement);
+    const courtId = attributes[httpSettings.selectors.courtIdAttr] ||
+      attributes[(httpSettings.selectors.courtIdAttr || '').replace(/^data-/, '')] ||
+      attributes.idcourt ||
+      attributes.id ||
+      null;
+    const courtName =
+      config?.courts?.[courtId] ||
+      ($(courtElement)
+        .find(httpSettings.selectors.courtName)
+        .first()
+        .text()
+        .trim() || courtId || 'Inconnu');
+    $(courtElement)
+      .find(httpSettings.selectors.slotButton)
+      .each((_, button) => {
+        const $btn = $(button);
+        if ($btn.attr('disabled')) return;
+        if (
+          Array.isArray(httpSettings.selectors.skipDisabledClass) &&
+          httpSettings.selectors.skipDisabledClass.some((cls) => $btn.hasClass(cls))
+        ) {
+          return;
+        }
+        const text = $btn.text().replace(/\s+/g, ' ').trim();
+        if (!text) return;
+        const btnAttributes = extractAttributes(button);
+        const candidateIds = [
+          httpSettings.selectors.slotIdAttr,
+          'idhoraire',
+          'id-horaire',
+          'id',
+          'value',
+          'creneau',
+          'slot',
+          'idcreneau'
+        ]
+          .filter(Boolean)
+          .map((key) => btnAttributes[key] || btnAttributes[`data-${key}`] || null);
+        const slotId = candidateIds.find((val) => val != null && val !== '') || null;
+        slots.push({
+          courtId: courtId ? String(courtId) : undefined,
+          courtName,
+          hour: text,
+          slotId: slotId ? String(slotId) : undefined,
+          rawAttributes: btnAttributes,
+          source: 'html'
+        });
+      });
+  });
+  return { form, slots };
+}
+
+function parseSlotsFromJson(data, config) {
+  if (!data) return [];
+  const entries = Array.isArray(data)
+    ? data
+    : Array.isArray(data?.slots)
+    ? data.slots
+    : Array.isArray(data?.disponibilites)
+    ? data.disponibilites
+    : Array.isArray(data?.result)
+    ? data.result
+    : [];
+  return entries
+    .map((item) => {
+      if (!item || typeof item !== 'object') return null;
+      const courtId =
+        item.courtId ??
+        item.idcourt ??
+        item.idCourt ??
+        item.idTerrain ??
+        item.terrain ??
+        item.id_terrain;
+      const hour = item.hour ?? item.heure ?? item.creneau ?? item.time;
+      const slotId =
+        item.slotId ??
+        item.idHoraire ??
+        item.idhoraire ??
+        item.idcreneau ??
+        item.id_creneau;
+      const available = item.available ?? item.disponible ?? item.isAvailable;
+      if (available === false || available === 0 || available === '0') {
+        return null;
+      }
+      if (!courtId || !hour) {
+        return null;
+      }
+      return {
+        courtId: String(courtId),
+        courtName:
+          config?.courts?.[courtId] || item.courtName || item.nomCourt || `Terrain ${courtId}`,
+        hour: String(hour),
+        slotId: slotId ? String(slotId) : undefined,
+        raw: item,
+        source: 'json'
+      };
+    })
+    .filter(Boolean);
+}
+
+function formatDate(date, template) {
+  const dd = String(date.getDate()).padStart(2, '0');
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const yyyy = date.getFullYear();
+  return template
+    .replace(/DD/g, dd)
+    .replace(/MM/g, mm)
+    .replace(/YYYY/g, yyyy);
+}
+
+function resolveTargetDate(config, httpSettings) {
+  const reservationPage = httpSettings.endpoints.reservationPage || {};
+  let targetDate;
+  if (config.reservationDate) {
+    const [year, month, day] = config.reservationDate.split('-').map(Number);
+    targetDate = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  } else {
+    const advance = Number.isFinite(Number(config.bookingAdvance))
+      ? Number(config.bookingAdvance)
+      : 7;
+    targetDate = new Date();
+    targetDate.setHours(12, 0, 0, 0);
+    targetDate.setDate(targetDate.getDate() + advance);
+  }
+  return {
+    date: targetDate,
+    iso: formatDate(targetDate, 'YYYY-MM-DD'),
+    display: formatDate(targetDate, 'DD/MM/YYYY'),
+    formattedForRequest: formatDate(
+      targetDate,
+      reservationPage.dateFormat || 'DD/MM/YYYY'
+    ),
+    ajaxFormat: formatDate(
+      targetDate,
+      reservationPage.ajaxDateFormat || reservationPage.dateFormat || 'YYYY-MM-DD'
+    )
+  };
+}
+
+function buildHtmlHeaders(httpSettings) {
+  return {
+    ...httpSettings.requestHeaders?.html,
+    'User-Agent': httpSettings.userAgent
+  };
+}
+
+function createHttpClient(httpSettings) {
+  const jar = new CookieJar();
+  const client = wrapper(
+    axios.create({
+      withCredentials: true,
+      jar,
+      maxRedirects: 10,
+      headers: {
+        'User-Agent': httpSettings.userAgent
+      },
+      validateStatus: (status) => status >= 200 && status < 400
+    })
+  );
+  return { client, jar };
+}
+
+async function performLogin(client, config, runtime, httpSettings) {
+  const { log } = runtime;
+  const loginSettings = httpSettings.endpoints.login || {};
+  const loginUrl = loginSettings.url || config.loginUrl;
+  log('step', 'Authentification via HTTP...');
+  let payload = {};
+  if (loginSettings.fetchInitialPage !== false) {
+    const response = await client.get(loginUrl, {
+      headers: buildHtmlHeaders(httpSettings)
+    });
+    const { form } = parseSlotsFromHtml(response.data, config, httpSettings);
+    payload = { ...(form?.fields || {}) };
+  }
+  const usernameField = loginSettings.usernameField || 'email';
+  const passwordField = loginSettings.passwordField || 'pass';
+  payload[usernameField] = config.username;
+  payload[passwordField] = config.password;
+  if (loginSettings.staticFields) {
+    Object.assign(payload, loginSettings.staticFields);
+  }
+  const encoding = loginSettings.encoding || 'form';
+  if (encoding === 'json') {
+    await client.post(loginUrl, payload, {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } else {
+    const body = new URLSearchParams();
+    Object.entries(payload).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        body.append(key, String(value));
+      }
+    });
+    await client.post(loginUrl, body.toString(), {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+    });
+  }
+  log('success', 'Connexion HTTP effectuée.');
+}
+
+async function fetchReservationContext(client, config, runtime, httpSettings, target) {
+  const { log } = runtime;
+  const reservationSettings = httpSettings.endpoints.reservationPage || {};
+  const baseUrl = httpSettings.baseUrl || config.memberUrl;
+  const pageUrl = reservationSettings.url
+    ? reservationSettings.url
+    : new URL(reservationSettings.path || 'reservation.html', baseUrl).toString();
+  const url = new URL(pageUrl);
+  if (reservationSettings.dateQueryParam) {
+    url.searchParams.set(
+      reservationSettings.dateQueryParam,
+      target.formattedForRequest
+    );
+  }
+  log('step', `Chargement des créneaux pour le ${target.display}...`);
+  const response = await client.get(url.toString(), {
+    headers: buildHtmlHeaders(httpSettings)
+  });
+  let { form, slots } = parseSlotsFromHtml(response.data, config, httpSettings);
+  if ((!slots || slots.length === 0) && reservationSettings.ajaxEndpoint) {
+    const ajaxUrl = new URL(reservationSettings.ajaxEndpoint, baseUrl);
+    const ajaxMethod = (reservationSettings.ajaxMethod || 'GET').toUpperCase();
+    const ajaxParams = {
+      ...(reservationSettings.ajaxStaticParams || {}),
+      [
+        reservationSettings.ajaxDateParam ||
+          reservationSettings.dateQueryParam ||
+          'date'
+      ]: target.ajaxFormat
+    };
+    let ajaxResponse;
+    if (ajaxMethod === 'GET') {
+      const ajaxRequestUrl = new URL(ajaxUrl.toString());
+      Object.entries(ajaxParams).forEach(([key, value]) => {
+        ajaxRequestUrl.searchParams.set(key, String(value));
+      });
+      ajaxResponse = await client.get(ajaxRequestUrl.toString(), {
+        headers: reservationSettings.ajaxHeaders || {
+          Accept: 'application/json, text/javascript, */*;q=0.1'
+        }
+      });
+    } else {
+      const body = new URLSearchParams();
+      Object.entries(ajaxParams).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          body.append(key, String(value));
+        }
+      });
+      ajaxResponse = await client.post(ajaxUrl.toString(), body.toString(), {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          ...(reservationSettings.ajaxHeaders || {})
+        }
+      });
+    }
+    const ajaxType = reservationSettings.ajaxResponseType || 'json';
+    if (ajaxType === 'json') {
+      slots = parseSlotsFromJson(ajaxResponse.data, config);
+    } else {
+      const parsed = parseSlotsFromHtml(ajaxResponse.data, config, httpSettings);
+      slots = parsed.slots;
+    }
+  }
+  log('info', `${slots.length} créneau(x) disponible(s) récupéré(s).`);
+  return { form, slots, target };
+}
+
+async function submitReservation(
+  client,
+  config,
+  runtime,
+  httpSettings,
+  context,
+  selection
+) {
+  const { log } = runtime;
+  const finalizeSettings = httpSettings.endpoints.finalize || {};
+  const baseUrl = httpSettings.baseUrl || config.memberUrl;
+  let actionUrl = finalizeSettings.url;
+  if (!actionUrl && context.form?.action) {
+    actionUrl = new URL(context.form.action, baseUrl).toString();
+  }
+  if (!actionUrl && finalizeSettings.path) {
+    actionUrl = new URL(finalizeSettings.path, baseUrl).toString();
+  }
+  if (!actionUrl) {
+    actionUrl = new URL('reservation.html', baseUrl).toString();
+  }
+  const method = (finalizeSettings.method || context.form?.method || 'POST').toUpperCase();
+  const payload = { ...(context.form?.fields || {}) };
+  const fields = finalizeSettings.fields || {};
+  if (fields.court) {
+    payload[fields.court] = selection.slot.courtId;
+  }
+  if (fields.slot && selection.slot.slotId) {
+    payload[fields.slot] = selection.slot.slotId;
+  }
+  if (fields.hour) {
+    payload[fields.hour] = selection.slot.hour;
+  }
+  if (fields.date) {
+    payload[fields.date] = context.target.formattedForRequest;
+  }
+  if (fields.testMode && config.testMode) {
+    payload[fields.testMode] = '1';
+  }
+  if (Array.isArray(config.partners)) {
+    config.partners.forEach((partner) => {
+      if (!partner || !fields.partner) return;
+      const template = fields.partner;
+      const fieldName = template
+        .replace('{position}', String(partner.position ?? 0))
+        .replace('{index}', String(partner.position ?? 0))
+        .replace('{number}', String((partner.position ?? 0) + 1));
+      payload[fieldName] = partner.playerId;
+    });
+  }
+  log('step', 'Envoi du formulaire de réservation...');
+  if (config.testMode) {
+    log('info', 'Mode test activé, aucun appel HTTP final n\'est réalisé.');
+    return;
+  }
+  if (method === 'GET') {
+    const url = new URL(actionUrl);
+    Object.entries(payload).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        url.searchParams.set(key, String(value));
+      }
+    });
+    await client.get(url.toString(), { headers: finalizeSettings.headers || {} });
+  } else if (finalizeSettings.encoding === 'json') {
+    await client.post(actionUrl, payload, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(finalizeSettings.headers || {})
+      }
+    });
+  } else {
+    const body = new URLSearchParams();
+    Object.entries(payload).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        body.append(key, String(value));
+      }
+    });
+    await client.post(actionUrl, body.toString(), {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...(finalizeSettings.headers || {})
+      }
+    });
+  }
+  log('success', 'Réservation HTTP envoyée avec succès.');
+}
+
+async function runMockFlow(config, runtime, httpSettings, target) {
+  const { log } = runtime;
+  const mockSlots = httpSettings.mockData?.availableSlots || [];
+  log('step', 'Mode HTTP mock activé, simulation sans appels réseau.');
+  const selection = selectBestSlot(mockSlots, config, log);
+  if (!selection.slot) {
+    throw new Error(
+      'Mode mock: aucun créneau compatible avec les préférences fournies.'
+    );
+  }
+  log(
+    'success',
+    `Simulation: créneau ${selection.slot.hour} retenu sur ${selection.slot.courtName || selection.slot.courtId}.`
+  );
+  if (config.testMode) {
+    log('info', 'Mode test et mock actifs: aucune réservation réelle effectuée.');
+  }
+  if (httpSettings.mockData?.onSuccessMessage) {
+    log('info', httpSettings.mockData.onSuccessMessage);
+  }
+}
+
+export async function runHttpRunner({ config, runtime }) {
+  const httpSettings = deepMerge(DEFAULT_HTTP_SETTINGS, config.http || {});
+  httpSettings.baseUrl = httpSettings.baseUrl || config.memberUrl;
+  const { log } = runtime;
+  const target = resolveTargetDate(config, httpSettings);
+  log('info', `Date cible pour la réservation: ${target.display}`);
+  if ((httpSettings.mode || 'live') === 'mock') {
+    await runMockFlow(config, runtime, httpSettings, target);
+    return;
+  }
+  const { client } = createHttpClient(httpSettings);
+  await performLogin(client, config, runtime, httpSettings);
+  const context = await fetchReservationContext(
+    client,
+    config,
+    runtime,
+    httpSettings,
+    target
+  );
+  const selection = selectBestSlot(context.slots, config, log);
+  if (!selection.slot) {
+    throw new Error(
+      'Aucun créneau disponible ne correspond aux préférences fournies.'
+    );
+  }
+  const courtLabel =
+    selection.slot.courtName ||
+    config?.courts?.[selection.slot.courtId] ||
+    selection.slot.courtId;
+  log(
+    'success',
+    `Créneau retenu: ${selection.slot.hour} sur ${courtLabel} (court ${selection.slot.courtId || 'n/a'}).`
+  );
+  await submitReservation(
+    client,
+    config,
+    runtime,
+    httpSettings,
+    { ...context, target },
+    selection
+  );
+  log('success', 'Moteur HTTP terminé.');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,16 @@
       "name": "autopadel",
       "version": "1.0.0",
       "dependencies": {
+        "axios": "^1.12.2",
+        "axios-cookiejar-support": "^6.0.4",
+        "cheerio": "^1.1.2",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^4.17.1",
         "node-schedule": "^2.1.0",
         "nodemailer": "^6.7.0",
-        "puppeteer": "^24.10.2"
+        "puppeteer": "^24.10.2",
+        "tough-cookie": "^5.1.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -123,9 +127,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -177,6 +181,42 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-cookiejar-support": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-6.0.4.tgz",
+      "integrity": "sha512-4Bzj+l63eGwnWDBFdJHeGS6Ij3ytpyqvo//ocsb5kCLN/rKthzk27Afh2iSkZtuudOBkHUWWIcyCb4GKhXqovQ==",
+      "license": "MIT",
+      "dependencies": {
+        "http-cookie-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "axios": ">=0.20.0",
+        "tough-cookie": ">=4.0.0"
       }
     },
     "node_modules/b4a": {
@@ -290,6 +330,12 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -346,6 +392,48 @@
         "node": ">=6"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chromium-bidi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.1.0.tgz",
@@ -390,6 +478,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -478,6 +578,34 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -510,6 +638,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -534,6 +671,61 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1452169.tgz",
       "integrity": "sha512-FOFDVMGrAUNp0dDKsAU1TorWJUx2JOU1k9xdgBKKJF3IBh/Uhl2yswG5r3TEAOrCiGY2QRp1e6LVDQrCsTKO4g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.5.0",
@@ -582,6 +774,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -589,6 +806,18 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -634,6 +863,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -837,6 +1081,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -986,6 +1266,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -996,6 +1291,61 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-cookie-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-7.0.2.tgz",
+      "integrity": "sha512-aHaES6SOFtnSlmWu0yEaaQvu+QexUG2gscSAvMhJ7auzW8r/jYOgGrzuAm9G9nHbksuhz7Lw4zOwDHmfQaxZvw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0 || ^5.0.0",
+        "undici": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
       }
     },
     "node_modules/http-errors": {
@@ -1339,6 +1689,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1464,6 +1826,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -2026,6 +2437,24 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2033,6 +2462,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tslib": {
@@ -2059,6 +2500,15 @@
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.8.0",
@@ -2092,6 +2542,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,15 @@
     "test": "node index.mjs --config=config_test.js"
   },
   "dependencies": {
+    "axios": "^1.12.2",
+    "axios-cookiejar-support": "^6.0.4",
+    "cheerio": "^1.1.2",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.17.1",
     "node-schedule": "^2.1.0",
     "nodemailer": "^6.7.0",
-    "puppeteer": "^24.10.2"
+    "puppeteer": "^24.10.2",
+    "tough-cookie": "^5.1.2"
   }
 }

--- a/server.mjs
+++ b/server.mjs
@@ -114,7 +114,9 @@ app.post('/start', (req, res) => {
       preferredHour1 = '',
       preferredHour2 = '',
       preferredHour3 = '',
-      testMode = false
+      testMode = false,
+      engine = 'http',
+      httpMode = 'live'
     } = req.body;
 
     // Vérification supplémentaire pour éviter les opérations sur undefined
@@ -148,6 +150,10 @@ app.post('/start', (req, res) => {
     const baseConfigObject = {
       loginUrl: 'https://centralsportclub.gestion-sports.com/connexion.php?',
       memberUrl: 'https://centralsportclub.gestion-sports.com/membre/',
+      engine: engine || 'http',
+      http: {
+        mode: httpMode || 'live'
+      },
       username: username,
       password: password,
       useCourtPreferences: Boolean(preferredCourt && preferredCourt !== ''),


### PR DESCRIPTION
## Summary
- add a configurable HTTP automation runner with live/mock modes and supporting dependencies
- update index.mjs to share default configuration logic, select the HTTP engine, and keep the Puppeteer flow intact
- expose engine/http options via config and server so the UI can trigger the lighter runner by default

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca885a9cb08325be484bda622a57b4