### PR TITLE
Add File polyfill before loading axios in HTTP runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ autopadel/
 - **HTTP (`engine: "http"`)** : nouveau client léger qui rejoue directement les requêtes réseau. Il peut être configuré via la clé `http` du fichier `config.js` (sélecteurs spécifiques, endpoints, mode mock, etc.).
   - Pour des tests hors-ligne, définissez `http.mode: "mock"` et fournissez des créneaux fictifs (`http.mockData.availableSlots`).
   - En mode « live », le script tente la connexion et la réservation à partir des informations fournies, sans lancer Chromium.
+  - Un polyfill `File` est automatiquement appliqué pour assurer la compatibilité avec les versions de Node.js dépourvues de cette API globale.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a minimal File polyfill and load axios/axios-cookiejar-support dynamically in the HTTP runner
- make HTTP client creation asynchronous so dependencies are initialised after the polyfill
- document the automatic File polyfill in the HTTP engine section of the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ca8fdfd8c48325814bc70449395c31