### PR TITLE
Refine File polyfill initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ autopadel/
 - **HTTP (`engine: "http"`)** : nouveau client léger qui rejoue directement les requêtes réseau. Il peut être configuré via la clé `http` du fichier `config.js` (sélecteurs spécifiques, endpoints, mode mock, etc.).
   - Pour des tests hors-ligne, définissez `http.mode: "mock"` et fournissez des créneaux fictifs (`http.mockData.availableSlots`).
   - En mode « live », le script tente la connexion et la réservation à partir des informations fournies, sans lancer Chromium.
+  - Un polyfill `File` minimal est automatiquement appliqué pour assurer la compatibilité avec les versions de Node.js dépourvues de cette API globale ; si `Blob` est également absent, un fallback via `fetch-blob` est chargé avant initialisation.
 
 ---
 

--- a/http-runner.mjs
+++ b/http-runner.mjs
@@ -1,7 +1,144 @@
-import axios from 'axios';
-import { wrapper } from 'axios-cookiejar-support';
 import { CookieJar } from 'tough-cookie';
 import * as cheerio from 'cheerio';
+
+let axiosLoaderPromise = null;
+let filePolyfillPromise = null;
+
+async function ensureBlobAvailability() {
+  if (typeof globalThis.Blob === 'function') {
+    return;
+  }
+  const blobModule = await import('fetch-blob');
+  const blobCtor =
+    typeof blobModule?.default === 'function'
+      ? blobModule.default
+      : typeof blobModule?.Blob === 'function'
+        ? blobModule.Blob
+        : null;
+  if (!blobCtor) {
+    throw new Error(
+      "Impossible d'initialiser l'API Blob nécessaire au polyfill File."
+    );
+  }
+  globalThis.Blob = blobCtor;
+}
+
+async function ensureFilePolyfill() {
+  if (typeof globalThis.File === 'function') {
+    return;
+  }
+  if (!filePolyfillPromise) {
+    filePolyfillPromise = (async () => {
+      try {
+        await ensureBlobAvailability();
+
+        if (typeof globalThis.File !== 'function') {
+          const BlobCtor = globalThis.Blob;
+
+          class FilePolyfill extends BlobCtor {
+            constructor(fileBits, fileName, options = {}) {
+              if (arguments.length < 2) {
+                throw new TypeError(
+                  "Failed to construct 'File': 2 arguments required, but only " +
+                    arguments.length +
+                    ' present.'
+                );
+              }
+
+              const opts =
+                options && typeof options === 'object' ? options : {};
+              const blobOptions = {};
+              if (opts.type !== undefined) {
+                blobOptions.type = opts.type;
+              }
+              if (opts.endings !== undefined) {
+                blobOptions.endings = opts.endings;
+              }
+
+              super(fileBits, blobOptions);
+
+              const coercedLastModified =
+                opts.lastModified === undefined
+                  ? Date.now()
+                  : Number(opts.lastModified);
+              const safeLastModified = Number.isFinite(coercedLastModified)
+                ? coercedLastModified
+                : Date.now();
+              const webkitRelativePath =
+                typeof opts.webkitRelativePath === 'string'
+                  ? opts.webkitRelativePath
+                  : '';
+
+              Object.defineProperties(this, {
+                name: {
+                  value: String(fileName),
+                  writable: false,
+                  enumerable: false,
+                  configurable: false
+                },
+                lastModified: {
+                  value: safeLastModified,
+                  writable: false,
+                  enumerable: false,
+                  configurable: false
+                },
+                webkitRelativePath: {
+                  value: webkitRelativePath,
+                  writable: false,
+                  enumerable: false,
+                  configurable: false
+                }
+              });
+            }
+          }
+
+          Object.defineProperty(FilePolyfill.prototype, Symbol.toStringTag, {
+            value: 'File',
+            writable: false,
+            enumerable: false,
+            configurable: true
+          });
+
+          globalThis.File = FilePolyfill;
+        }
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Impossible d'initialiser le polyfill File: ${reason}`
+        );
+      }
+
+      if (typeof globalThis.File !== 'function') {
+        throw new Error(
+          "Le polyfill File n'a pas pu être initialisé. axios requiert l'API File en environnement Node.js."
+        );
+      }
+    })();
+  }
+  await filePolyfillPromise;
+}
+
+async function loadAxiosDependencies() {
+  if (!axiosLoaderPromise) {
+    axiosLoaderPromise = (async () => {
+      await ensureFilePolyfill();
+      const [{ default: axios }, cookieJarModule] = await Promise.all([
+        import('axios'),
+        import('axios-cookiejar-support')
+      ]);
+      const wrapper =
+        cookieJarModule.wrapper ||
+        (typeof cookieJarModule.default === 'function'
+          ? cookieJarModule.default
+          : cookieJarModule.default?.wrapper);
+      if (typeof wrapper !== 'function') {
+        throw new Error('axios-cookiejar-support wrapper helper non disponible.');
+      }
+      return { axios, wrapper };
+    })();
+  }
+  return axiosLoaderPromise;
+}
 
 const DEFAULT_HTTP_SETTINGS = {
   mode: 'live',
@@ -452,7 +589,8 @@ function buildHtmlHeaders(httpSettings) {
   };
 }
 
-function createHttpClient(httpSettings) {
+async function createHttpClient(httpSettings) {
+  const { axios, wrapper } = await loadAxiosDependencies();
   const jar = new CookieJar();
   const client = wrapper(
     axios.create({
@@ -693,7 +831,7 @@ export async function runHttpRunner({ config, runtime }) {
     await runMockFlow(config, runtime, httpSettings, target);
     return;
   }
-  const { client } = createHttpClient(httpSettings);
+  const { client } = await createHttpClient(httpSettings);
   await performLogin(client, config, runtime, httpSettings);
   const context = await fetchReservationContext(
     client,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^4.17.1",
+        "fetch-blob": "^3.2.0",
         "node-schedule": "^2.1.0",
         "nodemailer": "^6.7.0",
         "puppeteer": "^24.10.2",
@@ -1063,6 +1064,29 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -1664,6 +1688,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-schedule": {
@@ -2542,6 +2586,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.17.1",
+    "fetch-blob": "^3.2.0",
     "node-schedule": "^2.1.0",
     "nodemailer": "^6.7.0",
     "puppeteer": "^24.10.2",


### PR DESCRIPTION
## Summary
- factorise the HTTP runner File polyfill by isolating Blob initialisation via fetch-blob and avoiding repeated logic
- align the File polyfill with the platform behaviour by making metadata properties non-enumerable and installing the Symbol.toStringTag descriptor once

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ca8fdfd8c48325814bc70449395c31